### PR TITLE
fix: Remove trial credentials and update MYTHX_ETH_ADDRESS to MYTHX_USERNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,21 @@ This plugin brings MythX to Status Embark. Simply call `verify` from the Embark 
 
 ## QuickStart
 
-1. Create a `.env` file in the root of your project and provide your MythX login information. If omitted, MythX will run in trial mode.
+1. Create a `.env` file in the root of your project and provide your MythX login information. Free MythX accounts can be created at https://dashboard.mythx.io/#/registration.
 
 ```json
-MYTHX_ETH_ADDRESS="<mythx-address>"
+MYTHX_USERNAME="<mythx-username>"
 MYTHX_PASSWORD="<password>"
 ```
+
+> **NOTE:** `MYTHX_ETH_ADDRESS` in favour of `MYTHX_USERNAME` and will be removed in future versions. Please update your .env file or your environment variables accordingly. 
+
+`MYTHX_USERNAME` may be either of:
+* MythX User ID (assigned by MythX API to any registered user);
+* Ethereum address, if user account is associated with an address;
+* A verified email address, if the user account is associated with an email address, and that address has been verified by visiting the verification link in the verification email sent by the MythX API each time when user email is set or modified in the MythX settings.
+
+For more information, please see the [MythX API Login documentation](https://api.mythx.io/v1/openapi#operation/login).
 
 2. Run `verify [options] [contracts]` in the Embark console. When the call returns, it will look something like this:
 

--- a/mythx.js
+++ b/mythx.js
@@ -25,18 +25,21 @@ async function analyse(contracts, cfg, embark) {
         return 1
     }
 
+    if (process.env.MYTHX_ETH_ADDRESS) {
+        process.env.MYTHX_USERNAME = process.env.MYTHX_ETH_ADDRESS;
+        embark.logger.warn("The environment variable MYTHX_ETH_ADDRESS in favour of MYTHX_USERNAME and will be removed in future versions. Please update your .env file or your environment variables accordingly.");
+    }
+
     // Connect to MythX via armlet
-    if(!process.env.MYTHX_ETH_ADDRESS || !process.env.MYTHX_PASSWORD) {
-        embark.logger.error("Environment variables 'MYTHX_ETH_ADDRESS' and 'MYTHX_PASSWORD' not found. Continuing in evaluation mode.")
-        process.env.MYTHX_ETH_ADDRESS = "0x0000000000000000000000000000000000000000"
-        process.env.MYTHX_PASSWORD = "trial"
+    if(!process.env.MYTHX_USERNAME || !process.env.MYTHX_PASSWORD) {
+        throw new Error("Environment variables 'MYTHX_USERNAME' and 'MYTHX_PASSWORD' not found. Place these in a .env file in the root of your &ETH;App, add them in the CLI command, ie 'MYTHX_USERNAME=xyz MYTHX_PASSWORD=123 embark run', or add them to your system's environment variables.");
     }
 
     const armletClient = new armlet.Client(
     {
         clientToolName: "embark-mythx",
         password: process.env.MYTHX_PASSWORD,
-        ethAddress: process.env.MYTHX_ETH_ADDRESS,
+        ethAddress: process.env.MYTHX_USERNAME,
     })
     
     // Filter contracts based on parameter choice
@@ -85,7 +88,7 @@ async function getStatus(uuid, embark) {
     {
         clientToolName: "embark-mythx",
         password: process.env.MYTHX_PASSWORD,
-        ethAddress: process.env.MYTHX_ETH_ADDRESS,
+        ethAddress: process.env.MYTHX_USERNAME,
     })
     
     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "embark-mythx",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embark-mythx",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "MythX plugin for Status Embark",
   "repository": "github:flex-dapps/embark-mythx",
   "main": "index.js",


### PR DESCRIPTION
Remove automatically provided trial credentials when MythX API login environment variables are not provided by the user.

Deprecate the use of `MYTHX_ETH_ADDRESS` in favour of `MYTHX_USERNAME` environment variable.