### PR TITLE
Add summary, submit sources correctly

### DIFF
--- a/lib/issues2eslint.js
+++ b/lib/issues2eslint.js
@@ -150,7 +150,7 @@ class MythXIssues {
         const sourceLocation = this.sourceMappingDecoder.atIndex(instNum, this.deployedSourceMap);
         assert(sourceLocation, 'sourceMappingDecoder.atIndex() should not return null');
         const loc = this.sourceMappingDecoder
-            .convertOffsetToLineColumn(sourceLocation, lineBreakPositions);
+            .convertOffsetToLineColumn(sourceLocation, lineBreakPositions || []);
 
         if (loc.start) {
             loc.start.line++;
@@ -172,7 +172,7 @@ class MythXIssues {
             start: parseInt(ary[0], 10),
         };
         const loc = this.sourceMappingDecoder
-            .convertOffsetToLineColumn(sourceLocation, lineBreakPositions);
+            .convertOffsetToLineColumn(sourceLocation, lineBreakPositions || []);
         if (loc.start) {
             loc.start.line++;
         }
@@ -271,6 +271,7 @@ function doReport(config, objects, errors, notAnalyzedContracts) {
     const eslintIssuesByBaseName = groupEslintIssuesByBasename(eslintIssues);
 
     const uniqueIssues = getUniqueIssues(eslintIssuesByBaseName);
+    printSummary(objects, uniqueIssues, config.logger);
     const formatter = getFormatter(config.style);
     const report = formatter(uniqueIssues);
     config.logger.info(report);
@@ -315,6 +316,29 @@ function doReport(config, objects, errors, notAnalyzedContracts) {
     }
 
     return ret;
+}
+
+function printSummary(objects, uniqueIssues, logger) {
+    if (objects && objects.length) {
+        logger.info('\nMythX Report Summary'.underline.bold);
+
+        const groupBy = 'groupId';
+        const groups = objects.reduce((accum, curr) => {
+            const issue = uniqueIssues.find((issue) => issue.filePath === curr.buildObj.mainSource);
+            const issueCount = issue.errorCount + issue.warningCount;
+            const marking = issueCount > 0 ? '✖'.red : '✔︎'.green;
+            (accum[curr[groupBy]] = accum[curr[groupBy]] || []).push(`   ${marking} ${issue.filePath.cyan}: ${issueCount} issues ${curr.uuid.dim.bold}`);
+            return accum;
+        }, {});
+
+        let count = 0;
+        Object.keys(groups).forEach((groupId) => {
+            logger.info(` ${++count}. Group ${groupId.bold.dim}:`);
+            Object.values(groups[groupId]).forEach((contract) => {
+                logger.info(contract);
+            });
+        });
+    }
 }
 
 function getFormatter(style) {

--- a/lib/mythXUtil.js
+++ b/lib/mythXUtil.js
@@ -47,14 +47,20 @@ const buildRequestData = contractObjects => {
         const contractFile = contractObjects.contracts[fileKey];
 
         Object.keys(contractFile).forEach(function(contractKey, index) {
-            const contractJSON = contractFile[contractKey]
+            const contractJSON = contractFile[contractKey];
+            const sourcesToInclude = Object.keys(JSON.parse(contractJSON.metadata).sources);
+            const sourcesFiltered = Object.entries(allSources).filter(([filename, { ast }]) => sourcesToInclude.includes(ast.absolutePath));
+            const sources = {};
+            sourcesFiltered.forEach(([key, value]) => {
+                sources[key] = value;
+            });
             const contract = {
                 contractName: contractKey,
                 bytecode: contractJSON.evm.bytecode.object,
                 deployedBytecode: contractJSON.evm.deployedBytecode.object,
                 sourceMap: contractJSON.evm.bytecode.sourceMap,
                 deployedSourceMap: contractJSON.evm.deployedBytecode.sourceMap,
-                sources: allSources,
+                sources,
                 sourcePath: fileKey
             };
 
@@ -162,7 +168,7 @@ const cleanAnalyzeDataEmptyProps = (data, debug, logger) => {
     }
 
     if (debug && unusedFields.length > 0) {
-        logger(`${props.contractName}: Empty JSON data fields from compilation - ${unusedFields.join(', ')}`);
+        logger.debug(`${props.contractName}: Empty JSON data fields from compilation - ${unusedFields.join(', ')}`);
     }
 
     return result;

--- a/mythx.js
+++ b/mythx.js
@@ -9,6 +9,18 @@ const { MythXIssues, doReport } = require('./lib/issues2eslint');
 
 const defaultConcurrentAnalyses = 4
 
+function checkEnvVariables(embark) {
+    if (process.env.MYTHX_ETH_ADDRESS) {
+        process.env.MYTHX_USERNAME = process.env.MYTHX_ETH_ADDRESS;
+        embark.logger.warn("The environment variable MYTHX_ETH_ADDRESS has been deprecated in favour of MYTHX_USERNAME and will be removed in future versions. Please update your .env file or your environment variables accordingly.");
+    }
+
+    // Connect to MythX via armlet
+    if (!process.env.MYTHX_USERNAME || !process.env.MYTHX_PASSWORD) {
+        throw new Error("Environment variables 'MYTHX_USERNAME' and 'MYTHX_PASSWORD' not found. Place these in a .env file in the root of your &ETH;App, add them in the CLI command, ie 'MYTHX_USERNAME=xyz MYTHX_PASSWORD=123 embark run', or add them to your system's environment variables.");
+    }
+}
+
 async function analyse(contracts, cfg, embark) {
 
     cfg.logger = embark.logger
@@ -25,15 +37,7 @@ async function analyse(contracts, cfg, embark) {
         return 1
     }
 
-    if (process.env.MYTHX_ETH_ADDRESS) {
-        process.env.MYTHX_USERNAME = process.env.MYTHX_ETH_ADDRESS;
-        embark.logger.warn("The environment variable MYTHX_ETH_ADDRESS in favour of MYTHX_USERNAME and will be removed in future versions. Please update your .env file or your environment variables accordingly.");
-    }
-
-    // Connect to MythX via armlet
-    if(!process.env.MYTHX_USERNAME || !process.env.MYTHX_PASSWORD) {
-        throw new Error("Environment variables 'MYTHX_USERNAME' and 'MYTHX_PASSWORD' not found. Place these in a .env file in the root of your &ETH;App, add them in the CLI command, ie 'MYTHX_USERNAME=xyz MYTHX_PASSWORD=123 embark run', or add them to your system's environment variables.");
-    }
+    checkEnvVariables(embark);
 
     const armletClient = new armlet.Client(
     {
@@ -83,16 +87,20 @@ async function analyse(contracts, cfg, embark) {
 
 async function getStatus(uuid, embark) {
 
+    checkEnvVariables(embark);
+
     // Connect to MythX via armlet
     const armletClient = new armlet.Client(
-    {
-        clientToolName: "embark-mythx",
-        password: process.env.MYTHX_PASSWORD,
-        ethAddress: process.env.MYTHX_USERNAME,
-    })
-    
+        {
+            clientToolName: "embark-mythx",
+            password: process.env.MYTHX_PASSWORD,
+            ethAddress: process.env.MYTHX_USERNAME,
+        });
+
+    await armletClient.login();
+
     try {
-        const results = await armletClient.getIssues(uuid);
+        const results = await armletClient.getIssues(uuid.toLowerCase());
         return ghettoReport(embark.logger, results);
     } catch (err) {
         embark.logger.warn(err);
@@ -115,7 +123,7 @@ const doAnalysis = async (armletClient, config, contracts, contractNames = null,
             initialDelay
         };
 
-        analyzeOpts.data = mythXUtil.cleanAnalyzeDataEmptyProps(obj.buildObj, config.debug, config.logger.debug);
+        analyzeOpts.data = mythXUtil.cleanAnalyzeDataEmptyProps(obj.buildObj, config.debug, config.logger);
         analyzeOpts.data.analysisMode = config.full ? "full" : "quick";
         if (config.debug > 1) {
             config.logger.debug("analyzeOpts: " + `${util.inspect(analyzeOpts, {depth: null})}`);
@@ -125,8 +133,9 @@ const doAnalysis = async (armletClient, config, contracts, contractNames = null,
         try {
             //TODO: Call analyze/analyzeWithStatus asynchronously
             config.logger.info("Submitting '" + obj.contractName + "' for " + analyzeOpts.data.analysisMode + " analysis...")
-            const {issues, status} = await armletClient.analyzeWithStatus(analyzeOpts);
+            const { issues, status } = await armletClient.analyzeWithStatus(analyzeOpts);
             obj.uuid = status.uuid;
+            obj.groupId = status.groupId;
 
             if (status.status === 'Error') {
                 return [status, null];


### PR DESCRIPTION
feat: Add summary of issues that includes the MythX group ID and report UUID:
![Summary](https://i.imgur.com/89LwfDx.png)

fix: Only source files in the AST are submitted as part of the MythX analysis
Previously, for every contract file submitted to MythX for analysis, **all** source contract files in the DApp were submitted as part of the MythX analysis job. This PR updates this functionality, such that only source files in the contract's AST are submitted along with the contract file as part of the MythX job. For example, if `ContractA` imports and inherits `ContractB`, when submitting a job to MythX for `ContractA`, `ContractB` would also be submitted in that job as as source file of `ContractA`. 

If we had two completely mutually exclusive contracts, `ContractA` and `Contract123`. When `ContractA` is submitted to MythX for analysis, only the `ContractA` source file will be submitted. Likewise for `Contract123`.

### Notes
1. In the MythX portal, some of the contracts are not showing the line numbers for the issues found, and are showing `undefined` instead. I'm not exactly sure what the source of this error is. 
2. Some of the issues reported by `embark-mythx` are not matching those listed in the MythX portal. This was raised in https://github.com/flex-dapps/embark-mythx/issues/10.
3. This needs to be tested and results confirmed

### Testing setup
This PR was tested with the following setup:
#### OpenZeppelin contracts
```
yarn add @openzeppelin/contracts
```
#### Contracts
`reentrancy.sol`
```
pragma solidity ^0.5.5;

// Bank is a contract vulnerable to re-entrancy attack. Let's see why.
// To illustrate this attack, we will use 2 accounts.
// First account - Innocent user
// Second account - Attacker

contract Bank {
    mapping(address => uint256) public balances;

    // Using the first account, deposit 1 Ether in to this contract
    function deposit() public payable {
        balances[msg.sender] += msg.value;
    }

    function withdraw(uint256 amount) public {
        if (balances[msg.sender] >= amount) {
            // Send Ether
            (bool sent, ) = msg.sender.call.value(amount)("");
            // Throw an error if send fails.
            require(sent, "Failed to send ether");

            balances[msg.sender] -= amount;
        }
    }

    // Helper function to check the total Ether stored in this contract
    function getTotalBalance() public view returns (uint256) {
        return address(this).balance;
    }
}

contract Hack {
    Bank public bank;

    constructor(Bank _bank) public {
        bank = _bank;
    }

    // This fallback is called when the Bank contract sends Ether to this contract.
    function() external payable {
        if (address(bank).balance >= msg.value) {
            bank.withdraw(msg.value);
        }
    }

    // Try:
    // Using the second account, call this function sending 1 Ether.
    function attack() public payable {
        bank.deposit.value(msg.value)();
        bank.withdraw(msg.value);
        // This contract should now have 2 Ethers:
        // 1 Ether stolen from the first account and
        // 1 Ether returned to this contract.
    }

    // Helper function to check the balance of this contract
    function getBalance() public view returns (uint256) {
        return address(this).balance;
    }
}
```
`contracts/GLDToken.sol`:
```
pragma solidity ^0.5.0;

import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
import "@openzeppelin/contracts/token/ERC20/ERC20Detailed.sol";

contract GLDToken is ERC20, ERC20Detailed {
    constructor(uint256 initialSupply) public ERC20Detailed("Gold", "GLD", 18) {
        _mint(msg.sender, initialSupply);
    }
}
```
`config/contracts.sol`:
```
deploy: {
      GLDToken: {
        args: [1000000]
      },
      Bank: {},
      Hack: {
        args: ["$Bank"]
      }
    }
```
`embark.json`:
```
"versions": {
    "solc": "0.5.5"
  },
```
